### PR TITLE
Moves the Meaning to the <note> field.

### DIFF
--- a/Tests/Translation/Dumper/xliff/structure_with_metadata.xml
+++ b/Tests/Translation/Dumper/xliff/structure_with_metadata.xml
@@ -10,9 +10,10 @@
         <source>Foo</source>
         <target state="new">Foo</target>
       </trans-unit>
-      <trans-unit id="5deead3ddeb268e61dbdf8809681afc61eabf8b4" resname="foo.bar.moo" extradata="Meaning: Bar">
+      <trans-unit id="5deead3ddeb268e61dbdf8809681afc61eabf8b4" resname="foo.bar.moo">
         <source>foo.bar.moo</source>
         <target state="new">foo.bar.moo</target>
+        <note>Bar</note>
       </trans-unit>
       <trans-unit id="cbcf5a897f5c5d204d78c3c4b2fdd517559cb1b9" resname="foo.baz">
         <source>foo.baz</source>

--- a/Tests/Translation/Dumper/xliff/with_metadata.xml
+++ b/Tests/Translation/Dumper/xliff/with_metadata.xml
@@ -6,9 +6,10 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
-      <trans-unit id="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" resname="foo" extradata="Meaning: baz">
+      <trans-unit id="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" resname="foo">
         <source>bar</source>
         <target state="new">bar</target>
+        <note>baz</note>
       </trans-unit>
     </body>
   </file>

--- a/Translation/Dumper/XliffDumper.php
+++ b/Translation/Dumper/XliffDumper.php
@@ -135,7 +135,7 @@ class XliffDumper implements DumperInterface
             }
 
             if ($meaning = $message->getMeaning()) {
-                $unit->setAttribute('extradata', 'Meaning: '.$meaning);
+                $unit->appendChild($doc->createElement('note', $meaning));
             }
 
         }

--- a/Translation/Loader/XliffLoader.php
+++ b/Translation/Loader/XliffLoader.php
@@ -66,11 +66,7 @@ class XliffLoader implements LoaderInterface
                 }
             }
 
-            if ($meaning = (string) $trans->attributes()->extradata) {
-                if (0 === strpos($meaning, 'Meaning: ')) {
-                    $meaning = substr($meaning, 9);
-                }
-
+            if ($meaning = (string) $trans->note) {
                 $m->setMeaning($meaning);
             }
 


### PR DESCRIPTION
- Updates example xliff's
- Updates dumper to use new field
- Updates loader to use new field
- Removes previx of "Meaning:"
